### PR TITLE
TEIID-2341 fixed cli script to match handler names to the web console

### DIFF
--- a/build/kits/jboss-as7/bin/scripts/teiid-add-database-logger.cli
+++ b/build/kits/jboss-as7/bin/scripts/teiid-add-database-logger.cli
@@ -8,10 +8,10 @@ batch
 deploy scripts/database-service.jar
 
 /subsystem=logging/custom-handler=TEIID_JPA_LOG:add(class=org.teiid.logger.DatabaseAppender, module=org.jboss.teiid.extensions, level=DEBUG)
-/subsystem=logging/async-handler=COMMAND_LOG:add(level=DEBUG, queue-length=50, overflow-action=BLOCK, subhandlers=[handle=TEIID_JPA_LOG], enabled=true)
-/subsystem=logging/async-handler=AUDIT_LOG:add(level=DEBUG, queue-length=50, overflow-action=BLOCK, subhandlers=[handle=TEIID_JPA_LOG], enabled=true)
+/subsystem=logging/async-handler=TEIID_COMMAND_LOG:add(level=DEBUG, queue-length=50, overflow-action=BLOCK, subhandlers=[handle=TEIID_JPA_LOG], enabled=true)
+/subsystem=logging/async-handler=TEIID_AUDIT_LOG:add(level=DEBUG, queue-length=50, overflow-action=BLOCK, subhandlers=[handle=TEIID_JPA_LOG], enabled=true)
 
-/subsystem=logging/logger=org.teiid.COMMAND_LOG:add(level=DEBUG, handlers=[handler=COMMAND_LOG])
-/subsystem=logging/logger=org.teiid.AUDIT_LOG:add(level=DEBUG, handlers=[handler=AUDIT_LOG])
+/subsystem=logging/logger=org.teiid.COMMAND_LOG:add(level=DEBUG, handlers=[handler=TEIID_COMMAND_LOG])
+/subsystem=logging/logger=org.teiid.AUDIT_LOG:add(level=DEBUG, handlers=[handler=TEIID_AUDIT_LOG])
 
 run-batch

--- a/database-service/pom.xml
+++ b/database-service/pom.xml
@@ -53,11 +53,6 @@
 			<groupId>org.jboss.teiid</groupId>
 			<artifactId>teiid-client</artifactId>
 			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.jboss.teiid</groupId>
-			<artifactId>teiid-client</artifactId>
-			<scope>provided</scope>
 		</dependency>	
         <dependency>
             <groupId>org.jboss.teiid</groupId>


### PR DESCRIPTION
TEIID-2341 fixed cli script to match handler names to the web console and also fixed a minor pom issue to remove duplicate definition

This fix needs to also be applied to the 0.0.x branch.
