### PR TITLE
Fix enable script in teiid-3336

### DIFF
--- a/build/kits/jboss-as7/bin/scripts/teiid-enable-database-logger.cli
+++ b/build/kits/jboss-as7/bin/scripts/teiid-enable-database-logger.cli
@@ -2,7 +2,7 @@ connect
 
 batch
 
-/subsystem=logging/logger=org.teiid.COMMAND_LOG:add(level=DEBUG, handlers=[handler=COMMAND_LOG])
-/subsystem=logging/logger=org.teiid.AUDIT_LOG:add(level=DEBUG, handlers=[handler=AUDIT_LOG])
+/subsystem=logging/logger=org.teiid.COMMAND_LOG:add(level=DEBUG, handlers=[handler=TEIID_COMMAND_LOG])
+/subsystem=logging/logger=org.teiid.AUDIT_LOG:add(level=DEBUG, handlers=[handler=TEIID_AUDIT_LOG])
 
 run-batch


### PR DESCRIPTION
The enable script had the old handler names and didn't get changed correctly.